### PR TITLE
Do not override telegraf.js error handling mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,53 +14,53 @@ This throttler aims to throttle incoming updates from Telegram, and outgoing cal
 
 ## Configuration
 The throttler accepts a single optional argument of the following form:
-```
+```typescript
 type ThrottlerOptions = {
-  group?: Bottleneck.ConstructorOptions,    # For throttling outgoing group messages
-  in?: Bottleneck.ConstructorOptions,       # For throttling incoming messages
-  out?: Bottleneck.ConstructorOptions,      # For throttling outgoing private messages
-  onThrottlerError?: ThrottlerErrorHandler, # For custom throttler error handling
+  group?: Bottleneck.ConstructorOptions,    // For throttling outgoing group messages
+  in?: Bottleneck.ConstructorOptions,       // For throttling incoming messages
+  out?: Bottleneck.ConstructorOptions,      // For throttling outgoing private messages
+  onThrottlerError?: ThrottlerErrorHandler, // For custom throttler error handling
 }
 ```
 
 The full list of object properties available for `Bottleneck.ConstructorOptions` can be found at [Bottleneck](https://github.com/SGrondin/bottleneck#constructor).
 
 If no argument is passed, the throttler created will use the default configuration settings which should be appropriate for most use cases. The default configuration are as follows:
-```
-# Outgoing Group Throttler
+```typescript
+// Outgoing Group Throttler
 const groupConfig = {
-  maxConcurrent: 1,                # Only 1 job at a time
-  minTime: 333,                    # Wait this many milliseconds to be ready, after a job
-  reservoir: 20,                   # Number of new jobs that throttler will accept at start
-  reservoirRefreshAmount: 20,      # Number of jobs that throttler will accept after refresh
-  reservoirRefreshInterval: 60000, # Interval in milliseconds where reservoir will refresh
+  maxConcurrent: 1,                // Only 1 job at a time
+  minTime: 333,                    // Wait this many milliseconds to be ready, after a job
+  reservoir: 20,                   // Number of new jobs that throttler will accept at start
+  reservoirRefreshAmount: 20,      // Number of jobs that throttler will accept after refresh
+  reservoirRefreshInterval: 60000, // Interval in milliseconds where reservoir will refresh
 };
 
-# Incoming Throttler
+// Incoming Throttler
 const inConfig = {
-  highWater: 0,                           # Trigger strategy if throttler is not ready for a new job
-  maxConcurrent: 1,                       # Only 1 job at a time
-  minTime: 333,                           # Wait this many milliseconds to be ready, after a job
-  strategy: Bottleneck.strategy.OVERFLOW, # Drop jobs if throttler is not ready
+  highWater: 0,                           // Trigger strategy if throttler is not ready for a new job
+  maxConcurrent: 1,                       // Only 1 job at a time
+  minTime: 333,                           // Wait this many milliseconds to be ready, after a job
+  strategy: Bottleneck.strategy.OVERFLOW, // Drop jobs if throttler is not ready
 }
 
-# Outgoing Private Throttler
+// Outgoing Private Throttler
 const outConfig = {
-  minTime: 25,                    # Wait this many milliseconds to be ready, after a job
-  reservoir: 30,                  # Number of new jobs that throttler will accept at start
-  reservoirRefreshAmount: 30,     # Number of jobs that throttler will accept after refresh
-  reservoirRefreshInterval: 1000, # Interval in milliseconds where reservoir will refresh
+  minTime: 25,                    // Wait this many milliseconds to be ready, after a job
+  reservoir: 30,                  // Number of new jobs that throttler will accept at start
+  reservoirRefreshAmount: 30,     // Number of jobs that throttler will accept after refresh
+  reservoirRefreshInterval: 1000, // Interval in milliseconds where reservoir will refresh
 };
 
-# Default Error Handler
+// Default Error Handler
 const defaultErrorHandler = async (ctx, next, throttlerName, error) => {
   return console.warn(`${throttlerName} | ${error.message}`)
 };
 ```
 
 ## Example
-```
-# Simple use case (Typescript)
+```typescript
+// Simple use case (Typescript)
 import { Telegraf } from 'telegraf';
 import telegrafThrottler from 'telegraf-throttler';
 
@@ -73,8 +73,8 @@ bot.command('/example', ctx => ctx.reply('I am throttled'));
 bot.launch();
 ```
 
-```
-# Simple use case (Javascript)
+```typescript
+// Simple use case (Javascript)
 const { Telegraf } = require('telegraf');
 const { telegrafThrottler } = require('telegraf-throttler');
 
@@ -87,20 +87,19 @@ bot.command('/example', ctx => ctx.reply('I am throttled'));
 bot.launch();
 ```
 
-```
-# Custom use case (Typescript)
+```typescript
+// Custom use case (Typescript)
 import { Telegraf } from 'telegraf';
 import telegrafThrottler from 'telegraf-throttler';
 
 const bot = new Telegraf(process.env.BOT_TOKEN);
 
-# 
 const throttler = telegrafThrottler({
   out: {
-    minTime: 25,                     # Wait this many milliseconds to be ready, after a job
-    reservoir: 3,                    # Number of new jobs that throttler will accept at start
-    reservoirRefreshAmount: 3,       # Number of jobs that throttler will accept after refresh
-    reservoirRefreshInterval: 10000, # Interval in milliseconds where reservoir will refresh
+    minTime: 25,                     // Wait this many milliseconds to be ready, after a job
+    reservoir: 3,                    // Number of new jobs that throttler will accept at start
+    reservoirRefreshAmount: 3,       // Number of jobs that throttler will accept after refresh
+    reservoirRefreshInterval: 10000, // Interval in milliseconds where reservoir will refresh
   },
 });
 bot.use(throttler);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf-throttler",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A middleware for Telegraf, that throttles inbound and outbound requests from Telegram",
   "author": "KnightNiwrem",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,10 +73,10 @@ export const telegrafThrottler = (
       const { chat_id } = data;
       const chatId = Number(chat_id);
       const hasEnabledWebhookReply = this.options.webhookReply;
-      const hasReponse = !!this.response;
-      const hasEndedReponse = this.responseEnd;
+      const hasResponse = !!this.response;
+      const hasEndedResponse = this.responseEnd;
       const isBlacklistedMethod = WEBHOOK_BLACKLIST.includes(method);
-      if (isNaN(chatId) || (hasEnabledWebhookReply && hasReponse && !hasEndedReponse && !isBlacklistedMethod)) {
+      if (isNaN(chatId) || (hasEnabledWebhookReply && hasResponse && !hasEndedResponse && !isBlacklistedMethod)) {
         return oldCallApi(method, data);
       }
 


### PR DESCRIPTION
Hi, KnightNiwrem! 

Thanks for your package! I'm using it and want to make an improvement (not backward compatible): 

Currently, when using `telegraf-throttler` it "overrides" build-it telegraf.js error handling, so this code is not working:

```typescript
const bot = new Telegraf(process.env.BOT_TOKEN)

bot.use(telegrafThrottler());

// This catch wont work
bot.catch((err, ctx) => {
  console.log(`Ooops, encountered an error for ${ctx.updateType}`, err)
})
bot.start((ctx) => {
  throw new Error('Example error')
})
bot.launch()
```

This PR makes `onThrottlerError` react only on `bottleneck`-related errors and allow to use standard telegraf.js catch methods.

This is also helpful when we need to catch and react on errors locally in bot. i.e.:

```typescript
.hears(/^s/, async (ctx: ContextMessageUpdate, next: any) => {
   try {
    await ctx.telegram.sendMessage(...)
  } catch (e) {
      console.log(e)
  }
})
```

