### PR TITLE
fix: add package homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
     "telegram",
     "throttle",
     "rate limit"
-  ]
+  ],
+  "homepage": "https://github.com/KnightNiwrem/telegraf-throttler#readme",
+  "bugs": {
+    "url": "https://github.com/KnightNiwrem/telegraf-throttler/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- Add `homepage` metadata pointing at the package README
- Add `bugs.url` metadata pointing at the GitHub issue tracker

## Why
The published `telegraf-throttler` package already declares its repository, but npm consumers do not get direct homepage or issue-tracker links from package metadata. This keeps the package metadata aligned with the existing GitHub project links.

## Validation
- `node` package metadata assertion
- `yarn install --frozen-lockfile --ignore-scripts`
- `npm pack --dry-run --json` (prepare/`yarn tsc` completed; package contains README, dist files, and package.json)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `homepage` and `bugs.url` fields to `telegraf-throttler`’s package metadata so npm shows direct links to the README and GitHub issues. Aligns the package metadata with the GitHub project.

<sup>Written for commit 66bdbc9ee9641af8154521564d54d5a18caea980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KnightNiwrem/telegraf-throttler/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with homepage and bug tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->